### PR TITLE
fix: correct faulty function call and namespace

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -24,6 +24,7 @@
  */
 
 use mod_swiftquiz\swiftquiz;
+use mod_swiftquiz\bank;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -77,7 +78,6 @@ function swiftquiz_view_tabs(swiftquiz $swiftquiz, string $tab) : string {
     }
     return print_tabs($tabs, $tab, $inactive, $activated, true);
 }
-namespace mod_swiftquiz;
 
 /**
  * Check if this swiftquiz has an open session.

--- a/view.php
+++ b/view.php
@@ -34,7 +34,7 @@ require_once($CFG->dirroot . '/question/editlib.php');
 
 $id = required_param('id', PARAM_INT);
 $cm             = get_coursemodule_from_id('swiftquiz', $id, 0, false, MUST_EXIST);
-$course         = $DB->get_records('course', array('id' => $cm->course), '*', MUST_EXIST);
+$course         = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
 require_login($course, true, $cm);
 
 /**


### PR DESCRIPTION
These issues in the latest release stopped me from using it. 

Fix #11 